### PR TITLE
Remove dependency on `unstable-list-lib`

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -7,8 +7,7 @@
     "draw-lib"
     "htdp-lib"
     "typed-racket-lib"
-    "typed-racket-more"
-    "unstable-contract-lib"))
+    "typed-racket-more"))
 (define build-deps
   '("scribble-lib"
     "racket-doc"

--- a/info.rkt
+++ b/info.rkt
@@ -8,7 +8,6 @@
     "htdp-lib"
     "typed-racket-lib"
     "typed-racket-more"
-    "unstable-list-lib"
     "unstable-contract-lib"))
 (define build-deps
   '("scribble-lib"

--- a/typed/2htdp/private/big-bang-wrapper.rkt
+++ b/typed/2htdp/private/big-bang-wrapper.rkt
@@ -5,7 +5,6 @@
 (require (for-syntax racket/base
                      racket/list
                      racket/function
-                     unstable/list
                      racket/syntax
                      syntax/parse)
          2htdp/universe)


### PR DESCRIPTION
Most of the functionality of that package will be moved into the core libraries by Racket PR #972, and `unstable-list-lib` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2. To preserve compatibility, you can create a Racket 6.2-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-list-lib` package, as it will not be part of the main distribution in future versions.
