### PR TITLE
Make color struct transparently available

### DIFF
--- a/typed/2htdp/image.rkt
+++ b/typed/2htdp/image.rkt
@@ -26,7 +26,7 @@
  2htdp/image
  ; 2.3.8 Image Predicates
  [#:opaque htdp:image image?]
- [#:opaque Color color?]
+ [#:struct Color color?]
  [#:opaque Pen pen?])
 
 ; provide capitalized predicates as well

--- a/typed/2htdp/image.rkt
+++ b/typed/2htdp/image.rkt
@@ -23,10 +23,14 @@
 ;; ---------------------------------------------------------------------------------------------------
 
 (require/typed/provide
+ mrlib/image-core
+ [#:struct color ([red : Byte] [green : Byte] [blue : Byte] [alpha : Byte])
+  #:type-name Color])
+
+(require/typed/provide
  2htdp/image
  ; 2.3.8 Image Predicates
  [#:opaque htdp:image image?]
- [#:opaque Color color?]
  [#:opaque Pen pen?])
 
 ; provide capitalized predicates as well
@@ -120,7 +124,6 @@
  ; 2.3.8 Image Predicates
  [mode? (Any -> Boolean)]
  [image-color? (Any -> Boolean)]
- [color ((Byte Byte Byte) (Byte) . ->* . Color)]
  [make-color ((Byte Byte Byte) (Byte) . ->* . Color)]
  [y-place? (Any -> Boolean)]
  [x-place? (Any -> Boolean)]

--- a/typed/2htdp/image.rkt
+++ b/typed/2htdp/image.rkt
@@ -26,6 +26,7 @@
  mrlib/image-core
  [#:struct color ([red : Byte] [green : Byte] [blue : Byte] [alpha : Byte])
   #:type-name Color])
+(provide Color)
 
 (require/typed/provide
  2htdp/image


### PR DESCRIPTION
Make the color structure available transparent (not opaque) to users.

Advantages: can use `struct-copy` as well as the `color-*` accessor methods.

Disadvantage: `color` is now the real constructor for the `Color` type, so requires four arguments. The `make-color` function can still be used with 3 arguments.

Explanation: I needed to get the color structure from mrlib/image-core instead of through 2htdp/image because 2htdp/image hides the color struct with a function that accepts 3 or 4 arguments and makes the color. 
