### PR TITLE
provide color accessors and test

### DIFF
--- a/test/color-test.rkt
+++ b/test/color-test.rkt
@@ -1,0 +1,27 @@
+#lang typed/racket
+(require typed/test-engine/racket-tests)
+(require "../typed/2htdp/image.rkt")
+
+(define a (color 10 20 30))
+(define b (make-color 40 50 60 70))
+
+(check-expect (color? a) true)
+(check-expect (color? b) true)
+
+(check-expect (color-red a) 10)
+(check-expect (color-green b) 50)
+(check-expect (color-blue a) 30)
+(check-expect (color-alpha b) 70)
+
+;(check-expect (color=? a a) true)
+;(check-expect (color=? a b) false)
+
+(define (sum-of-rgb [c : Color]) : Integer
+  (+ (color-red c)
+     (color-green c)
+     (color-blue c)))
+
+(check-expect (sum-of-rgb a) 60)
+
+(test)
+

--- a/typed/2htdp/image.rkt
+++ b/typed/2htdp/image.rkt
@@ -33,6 +33,7 @@
 (provide
  (rename-out [color? Color?]
              [pen? Pen?]))
+(provide Color color-red color-green color-blue color-alpha)
 
 ;; simple exports
 ;; ---------------------------------------------------------------------------------------------------
@@ -122,6 +123,10 @@
  [image-color? (Any -> Boolean)]
  [color ((Byte Byte Byte) (Byte) . ->* . Color)]
  [make-color ((Byte Byte Byte) (Byte) . ->* . Color)]
+ [color-red (Color . -> . Byte)]
+ [color-green (Color . -> . Byte)]
+ [color-blue (Color . -> . Byte)]
+ [color-alpha (Color . -> . Byte)]
  [y-place? (Any -> Boolean)]
  [x-place? (Any -> Boolean)]
  [angle? (Any -> Boolean)]


### PR DESCRIPTION
Leave Color opaque, provide accessors. Does not include color=?. Brief tests included.
